### PR TITLE
Add dockerfiles for build

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.eslint*
+.prettier*
+README.md
+Dockerfile*
+public
+.svelte-kit
+build

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:18.8-alpine3.15 as base
+
+# building
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn
+
+COPY . .
+
+RUN yarn build
+
+# running
+FROM node:18.8-bullseye-slim
+
+WORKDIR /app
+
+COPY --from=base /app .
+COPY . .
+
+EXPOSE 3000
+CMD ["node", "./build"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -14,8 +14,8 @@ FROM node:18.8-bullseye-slim
 
 WORKDIR /app
 
-COPY --from=base /app .
-COPY . .
+COPY --from=base /app/build build
+COPY package.json .
 
 EXPOSE 3000
 CMD ["node", "./build"]

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
 	"devDependencies": {
 		"@playwright/test": "^1.25.0",
 		"@sveltejs/adapter-auto": "next",
+		"@sveltejs/adapter-node": "^1.0.0-next.88",
 		"@sveltejs/kit": "next",
 		"@typescript-eslint/eslint-plugin": "^5.27.0",
 		"@typescript-eslint/parser": "^5.27.0",

--- a/client/svelte.config.js
+++ b/client/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-node';
 import preprocess from 'svelte-preprocess';
 
 /** @type {import('@sveltejs/kit').Config} */

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -154,6 +154,13 @@
     set-cookie-parser "^2.4.8"
     tiny-glob "^0.2.9"
 
+"@sveltejs/adapter-node@^1.0.0-next.88":
+  version "1.0.0-next.88"
+  resolved "https://registry.yarnpkg.com/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.88.tgz#3e9427eb0839b52c65743691de1cfcd5321743ba"
+  integrity sha512-N75E0tbq1+70/8lYUbttj7ry+5PDl7DB29aJqYIQQdnWMkIv0CPnH5ux4fwDuQJuhR7k1lfUbLd96JWwPBHvIg==
+  dependencies:
+    esbuild "^0.14.48"
+
 "@sveltejs/adapter-vercel@1.0.0-next.66":
   version "1.0.0-next.66"
   resolved "https://registry.yarnpkg.com/@sveltejs/adapter-vercel/-/adapter-vercel-1.0.0-next.66.tgz#71e4d484b70e6a3c27bf33779bc3f85720da6292"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,37 @@
+FROM golang:1.19-bullseye as base
+
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nothing" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid 65532 \
+    go-user
+RUN mkdir /pb_data && \
+    chown go-user:go-user /pb_data
+
+WORKDIR $GOPATH/src/plugin-platform/server/
+
+COPY . .
+
+RUN go mod download
+RUN go mod verify
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /main ./cmd/platform/main.go
+
+USER go-user:go-user
+
+ENTRYPOINT [ "/main" ]
+
+FROM gcr.io/distroless/static-debian11
+
+COPY --from=base /main .
+COPY --from=base /etc/passwd /etc/passwd
+COPY --from=base /etc/group /etc/group
+COPY --from=base /pb_data /pb_data
+
+USER go-user:go-user
+
+ENTRYPOINT [ "/main" ]
+CMD [ "serve" ]


### PR DESCRIPTION
This adds a Dockerfile for client and server with some extra notes:

* For the server, you *must* mount a volume to `/pb_data` to accommodate the sqlite files that get created.
* The server is pretty light at 39.8 MB on my machine
* This installs an adapter so svelte will work in a container as a 'live' service (the default adapter does not work for this use case)
* The client image size probably still needs some work, as it's 405MB
* The client container will be broken until the backend is configurable (then it should work with kubernetes, docker-compose *et al*).